### PR TITLE
Fix normal vector calculation

### DIFF
--- a/map_generator/pins.py
+++ b/map_generator/pins.py
@@ -155,9 +155,10 @@ def calculate_number_of_pins(border_length, scale_factor):
 
 
 def calculate_normal_vector(border, point, geom_a):
+    distance_on_border = border.project(point)
     delta = 0.01 * border.length
-    p1 = border.interpolate(max(0, point.distance(border) - delta))
-    p2 = border.interpolate(min(border.length, point.distance(border) + delta))
+    p1 = border.interpolate(max(0, distance_on_border - delta))
+    p2 = border.interpolate(min(border.length, distance_on_border + delta))
 
     dx = p2.x - p1.x
     dy = p2.y - p1.y


### PR DESCRIPTION
## Summary
- fix interpolation offset when computing normals for pins

## Testing
- `python -m py_compile map_generator/*.py rename.py scale.py`

------
https://chatgpt.com/codex/tasks/task_e_684887bba510832db73db713893ffaf7