### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=map_generator --cov-report=term-missing --cov-fail-under=100


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs dependencies, runs tests, and checks 100% coverage

## Testing
- `pytest -q`
- `pytest --cov=map_generator --cov-report=term-missing --cov-fail-under=100`


------
https://chatgpt.com/codex/tasks/task_e_684926ca62dc832d91b6d976654d8426