### PR TITLE
Integrate Python into Docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:20-slim
 
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g topojson-server topojson-simplify topojson-client
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -7,20 +7,17 @@ serve as historical reference.
 
 ## Quick start
 
-1. Install Python dependencies:
+1. Build the Docker image:
 
 ```bash
-pip install -r requirements.txt
+docker build -t topojson-tool .
 ```
 
-2. Prepare a simplified GeoJSON file. A helper script `run_topojson.sh` can run inside a
-docker container to build one from `source_data/gadm41_UKR_1.json` and output a smoothed
-file. After running it you will have a file like `source_data/simplified_gadm41_UKR_1_P-0.7.json`.
-
-3. Generate DXF maps:
+2. Run the helper script `run_topojson.sh`. It will create a simplified GeoJSON file and
+   generate the DXF maps in one go:
 
 ```bash
-python3 -m map_generator.generate path/to/simplified.geojson
+./run_topojson.sh
 ```
 
 DXF files will be placed in `tmp/` by default:
@@ -29,6 +26,14 @@ DXF files will be placed in `tmp/` by default:
 - `ukraine_pins.dxf` – pins
 - `ukraine_holes.dxf` – holes
 - `ukraine_full.dxf` – all features together
+
+If you prefer running the generator without Docker, install the Python
+requirements and call the script manually:
+
+```bash
+pip install -r requirements.txt
+python3 -m map_generator.generate path/to/simplified.geojson
+```
 
 ## Project structure
 

--- a/run_topojson.sh
+++ b/run_topojson.sh
@@ -8,17 +8,14 @@ echo "▶ Рівень спрощення (Planar Quantile): $SIMPLIFY_PLANAR_QU
 # Формуємо ім'я файлу для спрощеного GeoJSON
 SIMPLIFIED_FILE="source_data/simplified_gadm41_UKR_1_P-${SIMPLIFY_PLANAR_QUANTILE}.json"
 
-# Запуск контейнера для конвертації
+# Запуск контейнера для конвертації та генерації DXF
 docker run --rm -v $(pwd):/data topojson-tool bash -c "
     cd /data && \
     geo2topo -q 1e5 oblasts=source_data/gadm41_UKR_1.json > ukraine.topojson && \
     toposimplify -P $SIMPLIFY_PLANAR_QUANTILE -f < ukraine.topojson > ukraine_simplified.topojson && \
     node smooth_topojson.js && \
-    topo2geo oblasts=$SIMPLIFIED_FILE < ukraine_smoothed.topojson
+    topo2geo oblasts=$SIMPLIFIED_FILE < ukraine_smoothed.topojson && \
+    echo '✅ Спрощений GeoJSON збережено: $SIMPLIFIED_FILE' && \
+    echo '🚀 Генерація DXF...' && \
+    python3 -m map_generator.generate $SIMPLIFIED_FILE
 "
-
-echo "✅ Спрощений GeoJSON збережено: $SIMPLIFIED_FILE"
-
-# Запуск Python-скрипта для генерації DXF
-echo "🚀 Генерація DXF..."
-python3 -m map_generator.generate "$SIMPLIFIED_FILE"


### PR DESCRIPTION
## Summary
- extend Dockerfile with Python runtime and project requirements
- update helper script to run DXF generation inside the container
- simplify quick start instructions for Docker usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492a75c78c832d81260d0268de18bc