### PR TITLE
Improve DXF viewer and update Node

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "map_tiles",
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-22",
     "features": {
         "ghcr.io/devcontainers/features/python:1": {
             "version": "3.11"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 RUN apt-get update && \
     apt-get install -y python3 python3-pip && \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ DXF files will be placed in `tmp/` by default:
 - `ukraine_holes.dxf` – holes
 - `ukraine_full.dxf` – all features together
 
+## Previewing DXF files
+
+A simple web viewer is available at `viewer/index.html`. Open this file in your
+browser (for example using the VS Code Live Preview extension) and choose one of
+the generated DXF files from the `tmp/` directory to inspect it.
+
 If you prefer running the generator without Docker, install the Python
 requirements and call the script manually:
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>DXF Viewer</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    #viewer { width: 100%; height: calc(100vh - 40px); }
+    #fileInput { margin: 10px; }
+  </style>
+</head>
+<body>
+  <input type="file" id="fileInput" accept=".dxf" />
+  <div id="viewer"></div>
+
+  <script src="https://unpkg.com/three@0.154.0/build/three.min.js"></script>
+  <script src="https://unpkg.com/dxf-parser@1.1.2/dist/dxf-parser.js"></script>
+  <script src="https://unpkg.com/three-dxf@1.3.1/dist/three-dxf.js"></script>
+  <script>
+    const input = document.getElementById('fileInput');
+    const container = document.getElementById('viewer');
+    let canvas;
+
+    function loadFont(callback) {
+      const loader = new THREE.FontLoader();
+      loader.load('https://unpkg.com/three@0.154.0/examples/fonts/helvetiker_regular.typeface.json', callback);
+    }
+
+    input.addEventListener('change', () => {
+      const file = input.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const parser = new window.DxfParser();
+        let dxf;
+        try {
+          dxf = parser.parseSync(reader.result);
+        } catch (err) {
+          alert('Error parsing DXF: ' + err.message);
+          return;
+        }
+        container.innerHTML = '';
+        loadFont((font) => {
+          canvas = new window.ThreeDxf.Viewer(dxf, container, container.clientWidth, container.clientHeight, font);
+        });
+      };
+      reader.readAsText(file);
+    });
+
+    window.addEventListener('resize', () => {
+      if (canvas && typeof canvas.resize === 'function') {
+        canvas.resize(container.clientWidth, container.clientHeight);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- bump Node image to `22-slim`
- update devcontainer image
- make DXF viewer responsive to window resizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e7eaeec94832d967e7ca73766ba5a